### PR TITLE
Fix: Allow new games after one concludes in the same lobby

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -232,6 +232,10 @@ io.on('connection', (socket) => {
     // If game ended, notify about the result
     if (move.isCheckmate) {
       io.to(serverId).emit('gameEnded', game);
+      // Reset server state for a new game
+      server.gameStarted = false;
+      server.games = {}; // Clear the games log for this server
+      io.emit('serverUpdated', server); // Notify clients the server is ready for a new game
     }
   });
 
@@ -325,6 +329,11 @@ io.on('connection', (socket) => {
 
     // Notify both players about the game end
     io.to(serverId).emit('gameEnded', game);
+
+    // Reset server state for a new game
+    server.gameStarted = false;
+    server.games = {}; // Clear the games log for this server
+    io.emit('serverUpdated', server); // Notify clients the server is ready for a new game
   });
 
   // Handle timeout
@@ -345,6 +354,11 @@ io.on('connection', (socket) => {
 
     // Notify both players about the timeout
     io.to(serverId).emit('gameEnded', game);
+
+    // Reset server state for a new game
+    server.gameStarted = false;
+    server.games = {}; // Clear the games log for this server
+    io.emit('serverUpdated', server); // Notify clients the server is ready for a new game
   });
 
   // Handle player leaving (disconnecting)


### PR DESCRIPTION
Previously, the `server.gameStarted` flag and `server.games` object were not reset after a game ended normally (checkmate, resignation, timeout). This prevented players remaining in the same lobby from starting a new game, triggering a 'Game already started' error.

This commit modifies the `makeMove` (for checkmate), `resign`, and `timeOut` event handlers in `src/server.js` to:
- Set `server.gameStarted = false`.
- Reset `server.games = {}` for the affected server.
- Emit `serverUpdated` to notify clients that the server/lobby is ready for a new game.

This ensures that the server state is correctly updated, allowing for subsequent games to be initiated without issues.